### PR TITLE
Update referenced_glossaries.md

### DIFF
--- a/spec/referenced_glossaries.md
+++ b/spec/referenced_glossaries.md
@@ -14,7 +14,7 @@ The following glossaries were used as sources for some of the definitions in the
 
 | Short Name | Source Glossary | URL |
 |------------|-----------------|-----|
-| Wikipedia | Wikipedia | https://www.wikipedia.org/ |
+| Wikipedia | Wikipedia | [https://www.wikipedia.org/](https://en.wikipedia.org/wiki/Main_Page) |
 | eSSIF-Lab | eSSIF-Lab Glossary | https://essif-lab.github.io/framework/docs/essifLab-glossary |
 | NIST-CSRC | NIST Computer Security Resource Center Glossary | https://csrc.nist.gov/glossary/ |
 | PEMC IGR | Kantara Privacy Enhancing Mobile Credentials Implementors Guidance Report | https://kantarainitiative.org/download/pemc-implementors-guidance-report/ |


### PR DESCRIPTION
Modified the referenced URL for the English Wikipedia in line with the issue filed https://github.com/trustoverip/ctwg-main-glossary/issues/33